### PR TITLE
Clear test task before re-defining it

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -61,6 +61,7 @@ namespace :test do
 end
 
 desc "run all tests"
+Rake::Task['test'].clear
 task :test => ["test:mtest", "test:bintest"]
 
 desc "cleanup"

--- a/mrblib/setup.rb
+++ b/mrblib/setup.rb
@@ -261,6 +261,7 @@ namespace :test do
 end
 
 desc "run all tests"
+Rake::Task['test'].clear
 task :test => ["test:mtest", "test:bintest"]
 
 desc "cleanup"


### PR DESCRIPTION
This fixes a bug where "rake test" executes the MRuby task, and not ours
