### PR TITLE
Add build_mrbtest_lib_only to x86_64-apple-darwin14

### DIFF
--- a/mrblib/setup.rb
+++ b/mrblib/setup.rb
@@ -145,6 +145,8 @@ MRuby::CrossBuild.new('x86_64-apple-darwin14') do |conf|
   conf.build_target     = 'x86_64-pc-linux-gnu'
   conf.host_target      = 'x86_64-apple-darwin14'
 
+  conf.build_mrbtest_lib_only
+
   gem_config(conf)
 end
 


### PR DESCRIPTION
I think this was missed in 2fc24f2dea41332bab25e86b8eab25e221449b0c
