### PR TITLE
Only clear test task if already defined

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,7 @@ namespace :test do
 end
 
 desc "run all tests"
-Rake::Task['test'].clear
+Rake::Task['test'].clear if Rake::Task.task_defined?('test')
 task :test => ['test:bintest', 'test:mtest']
 
 desc "cleanup"

--- a/mrblib/setup.rb
+++ b/mrblib/setup.rb
@@ -343,7 +343,7 @@ namespace :test do
 end
 
 desc "run all tests"
-Rake::Task['test'].clear
+Rake::Task['test'].clear if Rake::Task.task_defined?('test')
 task :test => ["test:mtest", "test:bintest"]
 
 desc "cleanup"


### PR DESCRIPTION
This fixes a bug where new apps, that don't have mruby cloned yet,
will not rake because the mruby task hasn't been loaded.
