### PR TITLE
A task to package mruby-cli as deb or rpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 mruby/
 releases/
+packages/

--- a/README.md
+++ b/README.md
@@ -125,3 +125,14 @@ This means that if you want to add a new rake task `my_task`, you need to add it
 Just type: `docker-compose run release`
 
 After this command finishes, you'll see the releases for each target in the `releases` directory.
+
+### Create package
+
+We can package the ad hoc release as deb, rpm, msi, or dmg for the following
+Linux.
+
+To create all the package, just type
+
+```
+docker-compose run package
+```

--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,10 @@ load "#{mruby_root}/Rakefile"
 
 desc "compile all the binaries"
 task :compile => [:all] do
+  MRuby.each_target do |target|
+    `#{target.cc.command} --version`
+    abort("Command #{target.cc.command} for #{target.name} is missing.") unless $?.success?
+  end
   %W(#{mruby_root}/build/x86_64-pc-linux-gnu/bin/#{APP_NAME} #{mruby_root}/build/i686-pc-linux-gnu/#{APP_NAME}").each do |bin|
     sh "strip --strip-unneeded #{bin}" if File.exist?(bin)
   end

--- a/Rakefile
+++ b/Rakefile
@@ -135,3 +135,185 @@ Rake.application.tasks.each do |task|
     end
   end
 end
+
+namespace :package do
+  require 'fileutils'
+  require 'tmpdir'
+  require_relative "#{MRUBY_ROOT}/../mrblib/mruby-cli/version"
+
+  version = MRubyCLI::Version::VERSION
+  release_dir = "releases/v#{version}"
+  package_dir = "packages/v#{version}"
+  release_path = Dir.pwd + "/../#{release_dir}"
+  package_path = Dir.pwd + "/../#{package_dir}"
+  FileUtils.mkdir_p(package_path)
+
+  def check_fpm_installed?
+    `gem list -i fpm`.chomp == "true"
+  end
+
+  def check_msi_installed?
+    `wixl --version`
+    $?.success?
+  end
+
+  def check_dmg_installed?
+    `genisoimage --version`
+    $?.success?
+  end
+
+  def wxs_content(version, arch)
+    arch_wxs = case arch
+      when "x86_64"
+        {
+          string: "64-bit",
+          program_files_folder: "ProgramFiles64Folder",
+          define: "<?define Win64 = \"yes\"?>"
+        }
+      else
+        {
+          string: "32-bit",
+          program_files_folder: "ProgramFilesFolder",
+          define: "<?define Win64 = \"no\"?>"
+        }
+    end
+
+    <<-EOF
+<?xml version='1.0' encoding='utf-8'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
+
+  #{arch_wxs[:define]}
+
+  <Product
+    Name='mruby-cli #{arch_wxs[:string]}'
+    Id='F43E56B6-5FF2-450C-B7B7-0B12BF066ABD'
+    Version='#{version}'
+    Language='1033'
+    Manufacturer='mruby-cli'
+    UpgradeCode='12268671-59a0-42d3-b1f2-79e52b5657a6'
+  >
+
+    <Package InstallerVersion="200" Compressed="yes" Comments="comments" InstallScope="perMachine"/>
+
+    <Media Id="1" Cabinet="cabinet.cab" EmbedCab="yes"/>
+
+    <Directory Id='TARGETDIR' Name='SourceDir'>
+      <Directory Id='#{arch_wxs[:program_files_folder]}' Name='PFiles'>
+        <Directory Id='INSTALLDIR' Name='mruby-cli'>
+          <Component Id='MainExecutable' Guid='3DCA4C4D-205C-4FA4-8BB1-C0BF41CA5EFA'>
+            <File Id='mruby-cliEXE' Name='mruby-cli.exe' DiskId='1' Source='mruby-cli.exe' KeyPath='yes'/>
+          </Component>
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <Feature Id='Complete' Level='1'>
+      <ComponentRef Id='MainExecutable' />
+    </Feature>
+  </Product>
+</Wix>
+    EOF
+  end
+
+  def info_plist_content(version, arch)
+    <<-EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>mruby-cli</string>
+  <key>CFBundleGetInfoString</key>
+  <string>mruby-cli #{version} #{arch}</string>
+  <key>CFBundleName</key>
+  <string>mruby-cli</string>
+  <key>CFBundleIdentifier</key>
+  <string>mruby-cli</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>#{version}</string>
+  <key>CFBundleSignature</key>
+  <string>mrbc</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+</dict>
+</plist>
+    EOF
+  end
+
+  def osx_setup_bash_path_script
+    <<-EOF
+#!/bin/bash
+echo "export PATH=$PATH:/Applications/mruby-cli.app/Contents/MacOs" >> $HOME/.bash_profile
+source $HOME/.bash_profile
+    EOF
+  end
+
+  def log(package_dir, version, package)
+    puts "Writing packages #{package_dir}/#{version}/#{package}"
+  end
+
+  desc "create deb package"
+  task :deb => [:release] do
+    abort("fpm is not installed. Please check your docker install.") unless check_fpm_installed?
+
+    ["x86_64", "i686"].each do |arch|
+      release_tar_file = "mruby-cli-#{version}-#{arch}-pc-linux-gnu.tgz"
+      arch_name = (arch == "x86_64" ? "amd64" : arch)
+      log(package_dir, version, "mruby-cli_#{version}_#{arch_name}.deb")
+      `fpm -s tar -t deb -a #{arch} -n mruby-cli -v #{version} --prefix /usr/bin -p #{package_path} #{release_path}/#{release_tar_file}`
+    end
+  end
+
+  desc "create rpm package"
+  task :rpm => [:release] do
+    abort("fpm is not installed. Please check your docker install.") unless check_fpm_installed?
+
+    ["x86_64", "i686"].each do |arch|
+      release_tar_file = "mruby-cli-#{version}-#{arch}-pc-linux-gnu.tgz"
+      log(package_dir, version, "mruby-cli-#{version}-1.#{arch}.rpm")
+      `fpm -s tar -t rpm -a #{arch} -n mruby-cli -v #{version} --prefix /usr/bin -p #{package_path} #{release_path}/#{release_tar_file}`
+    end
+  end
+
+  desc "create msi package"
+  task :msi => [:release] do
+    abort("msitools is not installed.  Please check your docker install.") unless check_msi_installed?
+    ["x86_64", "i686"].each do |arch|
+      log(package_dir, version, "mruby-cli-#{version}-#{arch}.msi")
+      release_tar_file = "mruby-cli-#{version}-#{arch}-w64-mingw32.tgz"
+      Dir.mktmpdir do |dest_dir|
+        Dir.chdir dest_dir
+        `tar -zxf #{release_path}/#{release_tar_file}`
+        File.write("mruby-cli-#{version}-#{arch}.wxs", wxs_content(version, arch))
+        `wixl -v mruby-cli-#{version}-#{arch}.wxs && mv mruby-cli-#{version}-#{arch}.msi #{package_path}`
+      end
+    end
+  end
+
+  desc "create dmg package"
+  task :dmg => [:release] do
+    abort("dmg tools are not installed.  Please check your docker install.") unless check_dmg_installed?
+    ["x86_64", "i386"].each do |arch|
+      log(package_dir, version, "mruby-cli-#{version}-#{arch}.dmg")
+      release_tar_file = "mruby-cli-#{version}-#{arch}-apple-darwin14.tgz"
+      Dir.mktmpdir do |dest_dir|
+        Dir.chdir dest_dir
+        `tar -zxf #{release_path}/#{release_tar_file}`
+        FileUtils.chmod 0755, "mruby-cli"
+        FileUtils.mkdir_p "mruby-cli.app/Contents/MacOs"
+        FileUtils.mv "mruby-cli", "mruby-cli.app/Contents/MacOs"
+        File.write("mruby-cli.app/Contents/Info.plist", info_plist_content(version, arch))
+        File.write("add-mruby-cli-to-my-path.sh", osx_setup_bash_path_script)
+        FileUtils.chmod 0755, "add-mruby-cli-to-my-path.sh"
+        `genisoimage -V mruby-cli -D -r -apple -no-pad -o #{package_path}/mruby-cli-#{version}-#{arch}.dmg #{dest_dir}`
+      end
+    end
+  end
+
+end
+
+desc "create all packages"
+task :package => ["package:deb", "package:rpm", "package:msi", "package:dmg"]
+

--- a/bintest/mruby-cli.rb
+++ b/bintest/mruby-cli.rb
@@ -7,7 +7,7 @@ assert('setup') do
   Dir.mktmpdir do |tmp_dir|
     Dir.chdir(tmp_dir) do
       app_name = "new_cli"
-      output, status = Open3.capture2(BIN_PATH, "--setup", app_name)
+      output, status = Open3.capture2("#{BIN_PATH} --setup=#{app_name}")
 
       assert_true status.success?, "Process did not exit cleanly"
       assert_true Dir.exist?(app_name)

--- a/bintest/mruby-cli.rb
+++ b/bintest/mruby-cli.rb
@@ -25,13 +25,14 @@ assert('setup can compile and run the generated app') do
   Dir.mktmpdir do |tmp_dir|
     Dir.chdir(tmp_dir) do
       app_name = "hello_world"
+      APP_PATH = File.join("mruby/bin/#{app_name}")
       Open3.capture2(BIN_PATH, "--setup", app_name)
 
       Dir.chdir(app_name) do
         output, status = Open3.capture2("rake compile")
         assert_true status.success?, "`rake compile` did not exit cleanly"
 
-        output, status = Open3.capture2("mruby/bin/#{app_name}")
+        output, status = Open3.capture2(APP_PATH)
         assert_true status.success?, "`#{app_name}` did not exit cleanly"
         assert_include output, "Hello World"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,6 @@ shell:
 release:
   <<: *defaults
   command: rake release
+package:
+  <<: *defaults
+  command: rake package

--- a/mrblib/mruby-cli/setup.rb
+++ b/mrblib/mruby-cli/setup.rb
@@ -329,6 +329,11 @@ load "\#{mruby_root}/Rakefile"
 
 desc "compile binary"
 task :compile => [:all] do
+
+  MRuby.each_target do |target|
+    `\#{target.cc.command} --version`
+    abort("Command \#{target.cc.command} for \#{target.name} is missing.") unless $?.success?
+  end
   %W(\#{mruby_root}/build/x86_64-pc-linux-gnu/bin/\#{APP_NAME} \#{mruby_root}/build/i686-pc-linux-gnu/\#{APP_NAME}").each do |bin|
     sh "strip --strip-unneeded \#{bin}" if File.exist?(bin)
   end

--- a/mrblib/mruby-cli/setup.rb
+++ b/mrblib/mruby-cli/setup.rb
@@ -382,6 +382,34 @@ desc "cleanup"
 task :clean do
   sh "rake deep_clean"
 end
+
+namespace :local do
+  desc "show help"
+  task :version do
+    require_relative 'mrblib/mruby-cli/version'
+    puts "mruby-cli \#{MRubyCLI::Version::VERSION}"
+  end
+end
+
+def is_in_a_docker_container?
+  `grep -q docker /proc/self/cgroup`
+  $?.success?
+end
+
+Rake.application.tasks.each do |task|
+  next if ENV["MRUBY_CLI_LOCAL"]
+  unless task.name.start_with?("local:")
+    # Inspired by rake-hooks
+    # https://github.com/guillermo/rake-hooks
+    old_task = Rake.application.instance_variable_get('@tasks').delete(task.name)
+    desc old_task.full_comment
+    task old_task.name => old_task.prerequisites do
+      abort("Not running in docker, you should type \\"docker-compose run <task>\\".") \
+        unless is_in_a_docker_container?
+      old_task.invoke
+    end
+  end
+end
 RAKEFILE
     end
   end


### PR DESCRIPTION
Following discussion with @hone, here a first version allowing to package mruby-cli as a deb or rpm.

Some comments:
- It depend on the `fpm` Gem. As there is no Gemfile, I check if it is installed in the rake task.
- @hone suggested me to make it a mruby-gem so it could be reused. As I do not have yet found how to do it, I wanted already submit it in order to already collect your feedback. have you any ref about making a mruby gem?

Is there anything I do not do right?
