### PR TITLE
enable debug by default on host. create a separate 64-bit linux build

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ docker-compose run compile
 
 You'll be able to find the binaries in the following directories:
 
-* Linux (64-bit): `mruby/build/host/bin`
+* Linux (64-bit): `mruby/build/x86_64-pc-linux/bin`
 * Linux (32-bit): `mruby/build/i686-pc-linux-gnu/bin`
 * OS X (64-bit): `mruby/build/x86_64-apple-darwin14/bin/`
 * OS X (32-bit): `mruby/build/i386-apple-darwin14/bin`

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ load "#{mruby_root}/Rakefile"
 
 desc "compile all the binaries"
 task :compile => [:all] do
-  %W(#{mruby_root}/build/host/bin/#{APP_NAME} #{mruby_root}/build/i686-pc-linux-gnu/#{APP_NAME}").each do |bin|
+  %W(#{mruby_root}/build/x86_64-pc-linux-gnu/bin/#{APP_NAME} #{mruby_root}/build/i686-pc-linux-gnu/#{APP_NAME}").each do |bin|
     sh "strip --strip-unneeded #{bin}" if File.exist?(bin)
   end
 end
@@ -80,14 +80,12 @@ task :release do
   Dir.mktmpdir do |tmp_dir|
     Dir.chdir(tmp_dir) do
       MRuby.each_target do |target|
+        next if name == "host"
+
         arch = name
         bin  = "#{build_dir}/bin/#{exefile(APP_NAME)}"
         FileUtils.mkdir_p(name)
         FileUtils.cp(bin, name)
-        if name == "host"
-          arch = "x86_64-pc-linux-gnu"
-          FileUtils.mv("host", arch)
-        end
 
         Dir.chdir(arch) do
           arch_release = "#{app_name}-#{arch}"

--- a/build_config.rb
+++ b/build_config.rb
@@ -9,6 +9,15 @@ MRuby::Build.new do |conf|
   toolchain :gcc
 
   conf.enable_bintest
+  conf.enable_debug
+
+  gem_config(conf)
+end
+
+MRuby::Build.new('x86_64-pc-linux-gnu') do |conf|
+  toolchain :gcc
+
+  conf.build_mrbtest_lib_only
 
   gem_config(conf)
 end

--- a/mrblib/setup.rb
+++ b/mrblib/setup.rb
@@ -119,6 +119,15 @@ MRuby::Build.new do |conf|
   toolchain :clang
 
   conf.enable_bintest
+  conf.enable_debug
+
+  gem_config(conf)
+end
+
+MRuby::Build.new('x86_64-pc-linux-gnu') do |conf|
+  toolchain :gcc
+
+  conf.build_mrbtest_lib_only
 
   gem_config(conf)
 end
@@ -303,7 +312,7 @@ load "\#{mruby_root}/Rakefile"
 
 desc "compile binary"
 task :compile => [:all] do
-  %W(\#{mruby_root}/build/host/bin/\#{APP_NAME} \#{mruby_root}/build/i686-pc-linux-gnu/\#{APP_NAME}").each do |bin|
+  %W(\#{mruby_root}/build/x86_64-pc-linux-gnu/bin/\#{APP_NAME} \#{mruby_root}/build/i686-pc-linux-gnu/\#{APP_NAME}").each do |bin|
     sh "strip --strip-unneeded \#{bin}" if File.exist?(bin)
   end
 end


### PR DESCRIPTION
This let's us get backtraces when running mtests locally and in docker.
