### PR TITLE
version bump to 0.0.3

### DIFF
--- a/mrblib/mruby-cli/version.rb
+++ b/mrblib/mruby-cli/version.rb
@@ -1,6 +1,6 @@
 module MRubyCLI
   class Version
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
 
     def initialize(output_io)
       @output_io = output_io


### PR DESCRIPTION
Hi Terence,

I noticed that you put out released version `0.0.3` but the app reads `0.0.2`, and the `version.rb` file reads the older version as well.

Could you bump the version to reflect the same version as the release?
Also, could you tag the repo as well?

Thanks,
Keenan
