### PR TITLE
Fix c++ compiler for windows platforms

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -67,7 +67,7 @@ MRuby::CrossBuild.new('x86_64-w64-mingw32') do |conf|
   [conf.cc, conf.linker].each do |cc|
     cc.command = 'x86_64-w64-mingw32-gcc'
   end
-  conf.cxx.command      = 'x86_64-w64-mingw32-cpp'
+  conf.cxx.command      = 'x86_64-w64-mingw32-g++'
   conf.archiver.command = 'x86_64-w64-mingw32-gcc-ar'
   conf.exts.executable  = ".exe"
 
@@ -83,7 +83,7 @@ MRuby::CrossBuild.new('i686-w64-mingw32') do |conf|
   [conf.cc, conf.linker].each do |cc|
     cc.command = 'i686-w64-mingw32-gcc'
   end
-  conf.cxx.command      = 'i686-w64-mingw32-cpp'
+  conf.cxx.command      = 'i686-w64-mingw32-g++'
   conf.archiver.command = 'i686-w64-mingw32-gcc-ar'
   conf.exts.executable  = ".exe"
 


### PR DESCRIPTION
x86_64-w64-mingw32-cpp,i686-w64-mingw32-cpp does not compile c++ sources.

I'm tring to make [mruby-webcam](https://github.com/kjunichi/mruby-webcam) mrbgem works with mruby-cli.This works notice me that.

thank you.
