### PR TITLE
Should remain references to `MRUBY_VERSION` in Rakefile

### DIFF
--- a/mrblib/mruby-cli/setup.rb
+++ b/mrblib/mruby-cli/setup.rb
@@ -318,8 +318,8 @@ MRUBY_VERSION="1.2.0"
 
 file :mruby do
   #sh "git clone --depth=1 https://github.com/mruby/mruby"
-  sh "curl -L --fail --retry 3 --retry-delay 1 https://github.com/mruby/mruby/archive/#{MRUBY_VERSION}.tar.gz -s -o - | tar zxf -"
-  FileUtils.mv("mruby-#{MRUBY_VERSION}", "mruby")
+  sh "curl -L --fail --retry 3 --retry-delay 1 https://github.com/mruby/mruby/archive/\#{MRUBY_VERSION}.tar.gz -s -o - | tar zxf -"
+  FileUtils.mv("mruby-\#{MRUBY_VERSION}", "mruby")
 end
 
 APP_NAME=ENV["APP_NAME"] || "#{@name}"


### PR DESCRIPTION
Now Rakefile generated by `mruby-cli --setup` contains three `1.2.0` strings.
I guess that the original intention is to evaluate `MRUBY_VERSION` in Rakefile instead of evaluating it in this method.
