### PR TITLE
remove additional double quote

### DIFF
--- a/mrblib/mruby-cli/setup.rb
+++ b/mrblib/mruby-cli/setup.rb
@@ -347,7 +347,7 @@ task :compile => [:all] do
     `\#{target.cc.command} --version`
     abort("Command \#{target.cc.command} for \#{target.name} is missing.") unless $?.success?
   end
-  %W(\#{mruby_root}/build/x86_64-pc-linux-gnu/bin/\#{APP_NAME} \#{mruby_root}/build/i686-pc-linux-gnu/\#{APP_NAME}").each do |bin|
+  %W(\#{mruby_root}/build/x86_64-pc-linux-gnu/bin/\#{APP_NAME} \#{mruby_root}/build/i686-pc-linux-gnu/\#{APP_NAME}).each do |bin|
     sh "strip --strip-unneeded \#{bin}" if File.exist?(bin)
   end
 end


### PR DESCRIPTION
Currently generated Rakefile has additional double quote `"` in it.
This change is to remove it.
