### PR TITLE
Don't chdir globally

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,6 @@ mruby_config=File.expand_path(ENV["MRUBY_CONFIG"] || "build_config.rb")
 ENV['MRUBY_ROOT'] = mruby_root
 ENV['MRUBY_CONFIG'] = mruby_config
 Rake::Task[:mruby].invoke unless Dir.exist?(mruby_root)
-Dir.chdir(mruby_root)
 load "#{mruby_root}/Rakefile"
 
 load File.join(File.expand_path(File.dirname(__FILE__)), "mrbgem.rake")
@@ -27,12 +26,14 @@ APP_VERSION = (app_version.nil? || app_version.empty?) ? "unknown" : app_version
 
 desc "compile all the binaries"
 task :compile => [:all] do
-  MRuby.each_target do |target|
-    `#{target.cc.command} --version`
-    abort("Command #{target.cc.command} for #{target.name} is missing.") unless $?.success?
-  end
-  %W(#{mruby_root}/build/x86_64-pc-linux-gnu/bin/#{APP_NAME} #{mruby_root}/build/i686-pc-linux-gnu/#{APP_NAME}").each do |bin|
-    sh "strip --strip-unneeded #{bin}" if File.exist?(bin)
+  Dir.chdir(mruby_root) do
+    MRuby.each_target do |target|
+      `#{target.cc.command} --version`
+      abort("Command #{target.cc.command} for #{target.name} is missing.") unless $?.success?
+    end
+    %W(#{mruby_root}/build/x86_64-pc-linux-gnu/bin/#{APP_NAME} #{mruby_root}/build/i686-pc-linux-gnu/#{APP_NAME}).each do |bin|
+      sh "strip --strip-unneeded #{bin}" if File.exist?(bin)
+    end
   end
 end
 
@@ -40,12 +41,14 @@ namespace :test do
   desc "run mruby & unit tests"
   # only build mtest for host
   task :mtest => :compile do
-    # in order to get mruby/test/t/synatx.rb __FILE__ to pass,
-    # we need to make sure the tests are built relative from mruby_root
-    MRuby.each_target do |target|
-      # only run unit tests here
-      target.enable_bintest = false
-      run_test if target.test_enabled?
+    Dir.chdir(mruby_root) do
+      # in order to get mruby/test/t/synatx.rb __FILE__ to pass,
+      # we need to make sure the tests are built relative from mruby_root
+      MRuby.each_target do |target|
+        # only run unit tests here
+        target.enable_bintest = false
+        run_test if target.test_enabled?
+      end
     end
   end
 
@@ -63,9 +66,11 @@ namespace :test do
 
   desc "run integration tests"
   task :bintest => :compile do
-    MRuby.each_target do |target|
-      clean_env(%w(MRUBY_ROOT MRUBY_CONFIG)) do
-        run_bintest if target.bintest_enabled?
+    Dir.chdir(mruby_root) do
+      MRuby.each_target do |target|
+        clean_env(%w(MRUBY_ROOT MRUBY_CONFIG)) do
+          run_bintest if target.bintest_enabled?
+        end
       end
     end
   end
@@ -77,38 +82,42 @@ task :test => ['test:bintest', 'test:mtest']
 
 desc "cleanup"
 task :clean do
-  sh "rake deep_clean"
+  Dir.chdir(mruby_root) do
+    sh "rake deep_clean"
+  end
 end
 
 desc "generate a release tarball"
 task :release => :compile do
   require 'tmpdir'
 
-  # since we're in the mruby/
-  release_dir  = "releases/v#{APP_VERSION}"
-  release_path = Dir.pwd + "/../#{release_dir}"
-  app_name     = "#{APP_NAME}-#{APP_VERSION}"
-  FileUtils.mkdir_p(release_path)
+  Dir.chdir(mruby_root) do
+    # since we're in the mruby/
+    release_dir  = "releases/v#{APP_VERSION}"
+    release_path = Dir.pwd + "/../#{release_dir}"
+    app_name     = "#{APP_NAME}-#{APP_VERSION}"
+    FileUtils.mkdir_p(release_path)
 
-  Dir.mktmpdir do |tmp_dir|
-    Dir.chdir(tmp_dir) do
-      MRuby.each_target do |target|
-        next if name == "host"
+    Dir.mktmpdir do |tmp_dir|
+      Dir.chdir(tmp_dir) do
+        MRuby.each_target do |target|
+          next if name == "host"
 
-        arch = name
-        bin  = "#{build_dir}/bin/#{exefile(APP_NAME)}"
-        FileUtils.mkdir_p(name)
-        FileUtils.cp(bin, name)
+          arch = name
+          bin  = "#{build_dir}/bin/#{exefile(APP_NAME)}"
+          FileUtils.mkdir_p(name)
+          FileUtils.cp(bin, name)
 
-        Dir.chdir(arch) do
-          arch_release = "#{app_name}-#{arch}"
-          puts "Writing #{release_dir}/#{arch_release}.tgz"
-          `tar czf #{release_path}/#{arch_release}.tgz *`
+          Dir.chdir(arch) do
+            arch_release = "#{app_name}-#{arch}"
+            puts "Writing #{release_dir}/#{arch_release}.tgz"
+            `tar czf #{release_path}/#{arch_release}.tgz *`
+          end
         end
-      end
 
-      puts "Writing #{release_dir}/#{app_name}.tgz"
-      `tar czf #{release_path}/#{app_name}.tgz *`
+        puts "Writing #{release_dir}/#{app_name}.tgz"
+        `tar czf #{release_path}/#{app_name}.tgz *`
+      end
     end
   end
 end

--- a/mrblib/mruby-cli/setup.rb
+++ b/mrblib/mruby-cli/setup.rb
@@ -405,31 +405,33 @@ desc "generate a release tarball"
 task :release => :compile do
   require 'tmpdir'
 
-  # since we're in the mruby/
-  release_dir  = "releases/v\#{APP_VERSION}"
-  release_path = Dir.pwd + "/../\#{release_dir}"
-  app_name     = "\#{APP_NAME}-\#{APP_VERSION}"
-  FileUtils.mkdir_p(release_path)
+  Dir.chdir(mruby_root) do
+    # since we're in the mruby/
+    release_dir  = "releases/v\#{APP_VERSION}"
+    release_path = Dir.pwd + "/../\#{release_dir}"
+    app_name     = "\#{APP_NAME}-\#{APP_VERSION}"
+    FileUtils.mkdir_p(release_path)
 
-  Dir.mktmpdir do |tmp_dir|
-    Dir.chdir(tmp_dir) do
-      MRuby.each_target do |target|
-        next if name == "host"
+    Dir.mktmpdir do |tmp_dir|
+      Dir.chdir(tmp_dir) do
+        MRuby.each_target do |target|
+          next if name == "host"
 
-        arch = name
-        bin  = "\#{build_dir}/bin/\#{exefile(APP_NAME)}"
-        FileUtils.mkdir_p(name)
-        FileUtils.cp(bin, name)
+          arch = name
+          bin  = "\#{build_dir}/bin/\#{exefile(APP_NAME)}"
+          FileUtils.mkdir_p(name)
+          FileUtils.cp(bin, name)
 
-        Dir.chdir(arch) do
-          arch_release = "\#{app_name}-\#{arch}"
-          puts "Writing \#{release_dir}/\#{arch_release}.tgz"
-          `tar czf \#{release_path}/\#{arch_release}.tgz *`
+          Dir.chdir(arch) do
+            arch_release = "\#{app_name}-\#{arch}"
+            puts "Writing \#{release_dir}/\#{arch_release}.tgz"
+            `tar czf \#{release_path}/\#{arch_release}.tgz *`
+          end
         end
-      end
 
-      puts "Writing \#{release_dir}/\#{app_name}.tgz"
-      `tar czf \#{release_path}/\#{app_name}.tgz *`
+        puts "Writing \#{release_dir}/\#{app_name}.tgz"
+        `tar czf \#{release_path}/\#{app_name}.tgz *`
+      end
     end
   end
 end

--- a/mrblib/mruby-cli/setup.rb
+++ b/mrblib/mruby-cli/setup.rb
@@ -330,9 +330,7 @@ mruby_config=File.expand_path(ENV["MRUBY_CONFIG"] || "build_config.rb")
 ENV['MRUBY_ROOT'] = mruby_root
 ENV['MRUBY_CONFIG'] = mruby_config
 Rake::Task[:mruby].invoke unless Dir.exist?(mruby_root)
-Dir.chdir(mruby_root)
 load "\#{mruby_root}/Rakefile"
-
 
 load File.join(File.expand_path(File.dirname(__FILE__)), "mrbgem.rake")
 
@@ -342,13 +340,14 @@ APP_VERSION = (app_version.nil? || app_version.empty?) ? "unknown" : app_version
 
 desc "compile binary"
 task :compile => [:all] do
-
-  MRuby.each_target do |target|
-    `\#{target.cc.command} --version`
-    abort("Command \#{target.cc.command} for \#{target.name} is missing.") unless $?.success?
-  end
-  %W(\#{mruby_root}/build/x86_64-pc-linux-gnu/bin/\#{APP_NAME} \#{mruby_root}/build/i686-pc-linux-gnu/\#{APP_NAME}).each do |bin|
-    sh "strip --strip-unneeded \#{bin}" if File.exist?(bin)
+  Dir.chdir(mruby_root) do
+    MRuby.each_target do |target|
+      `\#{target.cc.command} --version`
+      abort("Command \#{target.cc.command} for \#{target.name} is missing.") unless $?.success?
+    end
+    %W(\#{mruby_root}/build/x86_64-pc-linux-gnu/bin/\#{APP_NAME} \#{mruby_root}/build/i686-pc-linux-gnu/\#{APP_NAME}).each do |bin|
+      sh "strip --strip-unneeded \#{bin}" if File.exist?(bin)
+    end
   end
 end
 
@@ -356,12 +355,14 @@ namespace :test do
   desc "run mruby & unit tests"
   # only build mtest for host
   task :mtest => :compile do
-    # in order to get mruby/test/t/synatx.rb __FILE__ to pass,
-    # we need to make sure the tests are built relative from mruby_root
-    MRuby.each_target do |target|
-      # only run unit tests here
-      target.enable_bintest = false
-      run_test if target.test_enabled?
+    Dir.chdir(mruby_root) do
+      # in order to get mruby/test/t/synatx.rb __FILE__ to pass,
+      # we need to make sure the tests are built relative from mruby_root
+      MRuby.each_target do |target|
+        # only run unit tests here
+        target.enable_bintest = false
+        run_test if target.test_enabled?
+      end
     end
   end
 
@@ -379,9 +380,11 @@ namespace :test do
 
   desc "run integration tests"
   task :bintest => :compile do
-    MRuby.each_target do |target|
-      clean_env(%w(MRUBY_ROOT MRUBY_CONFIG)) do
-        run_bintest if target.bintest_enabled?
+    Dir.chdir(mruby_root) do
+      MRuby.each_target do |target|
+        clean_env(%w(MRUBY_ROOT MRUBY_CONFIG)) do
+          run_bintest if target.bintest_enabled?
+        end
       end
     end
   end
@@ -393,7 +396,9 @@ task :test => ["test:mtest", "test:bintest"]
 
 desc "cleanup"
 task :clean do
-  sh "rake deep_clean"
+  Dir.chdir(mruby_root) do
+    sh "rake deep_clean"
+  end
 end
 
 desc "generate a release tarball"


### PR DESCRIPTION
Calling Dir.chdir in top level of Rakefile makes us not to add any tasks which should run on project root directory.
IMO, it's better to show working directory per tasks explicitly than doing chdir it globally.
