### PR TITLE
Add object and library to windows executable config

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -69,7 +69,12 @@ MRuby::CrossBuild.new('x86_64-w64-mingw32') do |conf|
   end
   conf.cxx.command      = 'x86_64-w64-mingw32-g++'
   conf.archiver.command = 'x86_64-w64-mingw32-gcc-ar'
-  conf.exts.executable  = ".exe"
+
+  conf.exts do |exts|
+    exts.object = '.obj'
+    exts.executable = '.exe'
+    exts.library = '.lib'
+  end
 
   conf.build_target     = 'x86_64-pc-linux-gnu'
   conf.host_target      = 'x86_64-w64-mingw32'
@@ -85,7 +90,12 @@ MRuby::CrossBuild.new('i686-w64-mingw32') do |conf|
   end
   conf.cxx.command      = 'i686-w64-mingw32-g++'
   conf.archiver.command = 'i686-w64-mingw32-gcc-ar'
-  conf.exts.executable  = ".exe"
+
+  conf.exts do |exts|
+    exts.object = '.obj'
+    exts.executable = '.exe'
+    exts.library = '.lib'
+  end
 
   conf.build_target     = 'i686-pc-linux-gnu'
   conf.host_target      = 'i686-w64-mingw32'

--- a/mrblib/mruby-cli/setup.rb
+++ b/mrblib/mruby-cli/setup.rb
@@ -192,7 +192,12 @@ MRuby::CrossBuild.new('x86_64-w64-mingw32') do |conf|
   end
   conf.cxx.command      = 'x86_64-w64-mingw32-g++'
   conf.archiver.command = 'x86_64-w64-mingw32-gcc-ar'
-  conf.exts.executable  = ".exe"
+
+  conf.exts do |exts|
+    exts.object = '.obj'
+    exts.executable = '.exe'
+    exts.library = '.lib'
+  end
 
   conf.build_target     = 'x86_64-pc-linux-gnu'
   conf.host_target      = 'x86_64-w64-mingw32'
@@ -208,7 +213,12 @@ MRuby::CrossBuild.new('i686-w64-mingw32') do |conf|
   end
   conf.cxx.command      = 'i686-w64-mingw32-g++'
   conf.archiver.command = 'i686-w64-mingw32-gcc-ar'
-  conf.exts.executable  = ".exe"
+
+  conf.exts do |exts|
+    exts.object = '.obj'
+    exts.executable = '.exe'
+    exts.library = '.lib'
+  end
 
   conf.build_target     = 'i686-pc-linux-gnu'
   conf.host_target      = 'i686-w64-mingw32'


### PR DESCRIPTION
These are needed for building extensions on Windows
