### PR TITLE
add support verbose option with mtest

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ These tests are unit tests, are written in mruby, and go in the `test/` director
 $ docker-compose run mtest
 ```
 
+If you want to enable verbose option, to run them just execute:
+
+```sh
+$ docker-compose run mtest -v
+```
+
 #### bintest
 These are integration tests, are written in CRuby (MRI), and go in the `bintest/` directory. It tests the status and output of the host binary inside a docker container. To run them just execute:
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require 'fileutils'
 
+$verbose = Rake.verbose == Rake::FileUtilsExt::DEFAULT ? false : Rake.verbose
+
 MRUBY_VERSION="1.2.0"
 
 file :mruby do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,25 +2,40 @@ compile: &defaults
   build: .
   volumes:
     - .:/home/mruby/code:rw
-  command: rake compile
+  entrypoint:
+    - rake
+    - compile
 test:
   <<: *defaults
-  command: rake test
+  entrypoint:
+    - rake
+    - test
 bintest:
   <<: *defaults
-  command: rake test:bintest
+  entrypoint:
+    - rake
+    - test:bintest
 mtest:
   <<: *defaults
-  command: rake test:mtest
+  entrypoint:
+    - rake
+    - test:mtest
 clean:
   <<: *defaults
-  command: rake clean
+  entrypoint:
+    - rake
+    - clean
 shell:
   <<: *defaults
-  command: bash
+  entrypoint:
+    - bash
 release:
   <<: *defaults
-  command: rake release
+  entrypoint:
+    - rake
+    - release
 package:
   <<: *defaults
-  command: rake package
+  entrypoint:
+    - rake
+    - package

--- a/mrblib/mruby-cli/setup.rb
+++ b/mrblib/mruby-cli/setup.rb
@@ -298,31 +298,46 @@ compile: &defaults
   build: .
   volumes:
     - .:/home/mruby/code:rw
-  command: rake compile
+  entrypoint:
+    - rake
+    - compile
 test:
   <<: *defaults
-  command: rake test
+  entrypoint:
+    - rake
+    - test
 bintest:
   <<: *defaults
-  command: rake test:bintest
+  entrypoint:
+    - rake
+    - test:bintest
 mtest:
   <<: *defaults
-  command: rake test:mtest
+  entrypoint:
+    - rake
+    - test:mtest
 clean:
   <<: *defaults
-  command: rake clean
+  entrypoint:
+    - rake
+    - clean
 shell:
   <<: *defaults
-  command: bash
+  entrypoint:
+    - bash
 release:
   <<: *defaults
-  command: rake release
+  entrypoint:
+    - rake
+    - release
 DOCKER_COMPOSE_YML
     end
 
     def rakefile
       <<RAKEFILE
 require 'fileutils'
+
+$verbose = Rake.verbose == Rake::FileUtilsExt::DEFAULT ? false : Rake.verbose
 
 MRUBY_VERSION="1.2.0"
 


### PR DESCRIPTION
Hello, I want to specify verbose option when execute test:mtest task.
So, add passing rake verbose option to run_test method in `mruby/tasks/mruby_build.rake`.

example:

```
$ docker-compose run mtest -v
```

refs: https://github.com/mruby/mruby/blob/master/tasks/mruby_build.rake#L273