### PR TITLE
Docker-compose.yml missing keyword

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: "3.8"
+services:
 compile: &defaults
   build: .
   volumes:


### PR DESCRIPTION
When I installed `mruby-cli-0.0.4-x86_64-w64-mingw32.tgz` and setup the project, I could not run the docker compose file. It gave me this error

```shell
C:\Users\me\Downloads\tiles_test>docker compose run compile
validating C:\Users\me\Downloads\tiles_test\docker-compose.yml: (root) Additional property compile is not allowed
```

I solved it by adding two new lines that I assumed was missing from a typical `docker-compose.yml` file, which solved it! I guess the cause of this error was that I used a newer version of `docker compose`.